### PR TITLE
Stop localizing html tags

### DIFF
--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -3,6 +3,11 @@ require "pseudolocalization/version"
 module Pseudolocalization
   module I18n
     class Backend
+      BRACKET_START = '<'
+      BRACKET_END = '>'
+
+      VOWELS = %w(a e i o u y)
+
       LEET = {
         'a' => 'α',
         'b' => 'β',
@@ -56,11 +61,23 @@ module Pseudolocalization
         # replace html entities, we don't care
         result = result.gsub(/&[a-z]+;/, ' ')
 
-        # double all vowels in an attempt to increase words length
-        result = result.gsub(/[aeiouy]/) { |c| c * 2 }
+        outside_brackets = true
 
-        # replace chars with utf8 lookalike
-        result.gsub(/[a-z]/, LEET)
+        result.chars.map do |char|
+          if char == BRACKET_START
+            outside_brackets = false
+            char
+          elsif char == BRACKET_END
+            outside_brackets = true
+            char
+          elsif outside_brackets && LEET.key?(char)
+            ret = LEET[char]
+            ret = ret * 2 if VOWELS.include?(char)
+            ret
+          else
+            char
+          end
+        end.join
       end
     end
   end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -18,4 +18,8 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_pseudolocalizes
     assert_equal 'Hεεll00, ω00rld!', @backend.translate(:en, 'Hello, world!', {})
   end
+
+  def test_it_works_with_html_entities
+    assert_equal 'Plεεααsεε, <a href="#test">ͼl11ͼϏ hεεrεε</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
+  end
 end


### PR DESCRIPTION
Before;

> Please, <a href="#test">click here</a>!
> Plεεααsεε, <α hrεϝ="#ϯεsϯ">ͼl11ͼϏ hεεrεε</α>!

After;

> Please, <a href="#test">click here</a>!
> Plεεααsεε, <a href="#test">ͼl11ͼϏ hεεrεε</a>!

Note that the html tag is still valid and working as expected.