### PR TITLE
Translate complex objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.3
+  - 2.4.2
 before_install: gem install bundler -v 1.16.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+ruby '~> 2.4'
+
 source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,17 +33,19 @@ GEM
     thor (0.20.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
   minitest (~> 5.0)
   package_cloud
   pseudolocalization!
   rake (~> 10.0)
 
+RUBY VERSION
+   ruby 2.4.2p198
+
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  environment:
+    RAILS_ENV: test
+    RACK_ENV: test
+  ruby:
+    version:
+      2.4.2
+
+dependencies:
+  override:
+    - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+
+database:
+  override:
+    - echo "no database setup"

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -54,16 +54,27 @@ module Pseudolocalization
       end
 
       def translate(locale, key, options)
-        result = @old_backend.translate(locale, key, options)
+        translate_object(@old_backend.translate(locale, key, options))
+      end
 
-        return result unless result.is_a?(String)
+      def translate_object(object)
+        if object.is_a?(Hash)
+          object.transform_values { |value| translate_object(value) }
+        elsif object.is_a?(Array)
+          object.map { |value| translate_object(value) }
+        elsif object.is_a?(String)
+          translate_string(object)
+        else
+          object
+        end
+      end
 
-        # replace html entities, we don't care
-        result = result.gsub(/&[a-z]+;/, ' ')
+      def translate_string(string)
+        string = string.gsub(/&[a-z]+;/, ' ')
 
         outside_brackets = true
 
-        result.chars.map do |char|
+        string.chars.map do |char|
           if char == BRACKET_START
             outside_brackets = false
             char

--- a/pseudolocalization.gemspec
+++ b/pseudolocalization.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "package_cloud"

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -22,4 +22,12 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_works_with_html_entities
     assert_equal 'Plεεααsεε, <a href="#test">ͼl11ͼϏ hεεrεε</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
   end
+
+  def test_it_works_with_hashes
+    assert_equal({ name: 'Hεεll00, ω00rld!' }, @backend.translate(:en, { name: 'Hello, world!' }, {}))
+  end
+
+  def test_it_works_with_arrays
+    assert_equal(['Hεεll00, ω00rld!'], @backend.translate(:en, ['Hello, world!'], {}))
+  end
 end


### PR DESCRIPTION
Rails I18n framework allows you to call `translate` on a parent element, which will then return all of its children in the form of a hash. This is great, and used in many places across our repositories. Unfortunately, the current version of `pseudolocalization` would simply bypasses these entries as they're not strings. This PR is an attempt to fix that.

The two tests that I add are probably the best way to understand in more details what I mean;

```
def test_it_works_with_hashes
  assert_equal({ name: 'Hεεll00, ω00rld!' }, @backend.translate(:en, { name: 'Hello, world!' }, {}))
end

def test_it_works_with_arrays
  assert_equal(['Hεεll00, ω00rld!'], @backend.translate(:en, ['Hello, world!'], {}))
end
```

It relies on `transform_values`, which is Ruby 2.4 only, so I had to bump dependencies too.