### PR TITLE
Complete character translation list

### DIFF
--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -8,34 +8,60 @@ module Pseudolocalization
 
       VOWELS = %w(a e i o u y A E I O U Y)
 
-      LEET = {
+      LETTERS = {
         'a' => 'α',
-        'b' => 'β',
+        'b' => 'ḅ',
         'c' => 'ͼ',
-        'd' => 'd',
-        'e' => 'ε',
+        'd' => 'ḍ',
+        'e' => 'ḛ',
         'f' => 'ϝ',
-        'g' => 'g',
-        'h' => 'h',
-        'i' => '1',
-        'j' => 'ϳ',
-        'k' => 'Ϗ',
-        'l' => 'l',
-        'm' => 'ϻ',
-        'n' => 'ͷ',
-        'o' => '0',
-        'p' => 'ρ',
-        'q' => 'q',
-        'r' => 'r',
-        's' => 's',
-        't' => 'ϯ',
-        'u' => 'u',
-        'v' => 'v',
-        'w' => 'ω',
-        'x' => 'x',
-        'y' => 'ϒ',
-        'z' => 'z',
-      }
+        'g' => 'ḡ',
+        'h' => 'ḥ',
+        'i' => 'ḭ',
+        'j' => 'ĵ',
+        'k' => 'ḳ',
+        'l' => 'ḽ',
+        'm' => 'ṃ',
+        'n' => 'ṇ',
+        'o' => 'ṓ',
+        'p' => 'ṗ',
+        'q' => 'ʠ',
+        'r' => 'ṛ',
+        's' => 'ṡ',
+        't' => 'ṭ',
+        'u' => 'ṵ',
+        'v' => 'ṽ',
+        'w' => 'ẁ',
+        'x' => 'ẋ',
+        'y' => 'ẏ',
+        'z' => 'ẓ',
+        'A' => 'Ḁ',
+        'B' => 'Ḃ',
+        'C' => 'Ḉ',
+        'D' => 'Ḍ',
+        'E' => 'Ḛ',
+        'F' => 'Ḟ',
+        'G' => 'Ḡ',
+        'H' => 'Ḥ',
+        'I' => 'Ḭ',
+        'J' => 'Ĵ',
+        'K' => 'Ḱ',
+        'L' => 'Ḻ',
+        'M' => 'Ṁ',
+        'N' => 'Ṅ',
+        'O' => 'Ṏ',
+        'P' => 'Ṕ',
+        'Q' => 'Ǫ',
+        'R' => 'Ṛ',
+        'S' => 'Ṣ',
+        'T' => 'Ṫ',
+        'U' => 'Ṳ',
+        'V' => 'Ṿ',
+        'W' => 'Ŵ',
+        'X' => 'Ẋ',
+        'Y' => 'Ŷ',
+        'Z' => 'Ż',
+      }.freeze
 
       def initialize(old_backend)
         @old_backend = old_backend
@@ -81,8 +107,8 @@ module Pseudolocalization
           elsif char == BRACKET_END
             outside_brackets = true
             char
-          elsif outside_brackets && LEET.key?(char)
-            ret = LEET[char]
+          elsif outside_brackets && LETTERS.key?(char)
+            ret = LETTERS[char]
             ret = ret * 2 if VOWELS.include?(char)
             ret
           else

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -16,18 +16,18 @@ class PseudolocalizationTest < Minitest::Test
   end
 
   def test_it_pseudolocalizes
-    assert_equal 'Hεεll00, ω00rld!', @backend.translate(:en, 'Hello, world!', {})
+    assert_equal 'Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!', @backend.translate(:en, 'Hello, world!', {})
   end
 
   def test_it_works_with_html_entities
-    assert_equal 'Plεεααsεε, <a href="#test">ͼl11ͼϏ hεεrεε</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
+    assert_equal 'Ṕḽḛḛααṡḛḛ, <a href="#test">ͼḽḭḭͼḳ ḥḛḛṛḛḛ</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
   end
 
   def test_it_works_with_hashes
-    assert_equal({ name: 'Hεεll00, ω00rld!' }, @backend.translate(:en, { name: 'Hello, world!' }, {}))
+    assert_equal({ name: 'Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!' }, @backend.translate(:en, { name: 'Hello, world!' }, {}))
   end
 
   def test_it_works_with_arrays
-    assert_equal(['Hεεll00, ω00rld!'], @backend.translate(:en, ['Hello, world!'], {}))
+    assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
   end
 end


### PR DESCRIPTION
- Added translations for all capital letters and missing lowercase letters
- Changed a few lowercase translations to be more visually similar to their standard counterpart. 
- Renamed `LEET` to `LETTERS`
- Made `LETTERS` a constant hash via `freeze`
- Added capital letters to `VOWELS` array, to increase length of strings like "All", "Act", "Arc", "Egg", etc