### PR TITLE
Don't pseudotranslate liquid tags

### DIFF
--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -5,6 +5,8 @@ module Pseudolocalization
     class Backend
       BRACKET_START = '<'
       BRACKET_END = '>'
+      LIQUID_BRACKET_START = '⋖'
+      LIQUID_BRACKET_END = '⋗'
 
       VOWELS = %w(a e i o u y A E I O U Y)
 
@@ -98,13 +100,16 @@ module Pseudolocalization
       def translate_string(string)
         string = string.gsub(/&[a-z]+;/, ' ')
 
+        string = string.gsub(/{{/, '⋖')
+        string = string.gsub(/}}/, '⋗')
+
         outside_brackets = true
 
-        string.chars.map do |char|
-          if char == BRACKET_START
+        pseudostring = string.chars.map do |char|
+          if (char == BRACKET_START) || (char == LIQUID_BRACKET_START)
             outside_brackets = false
             char
-          elsif char == BRACKET_END
+          elsif (char == BRACKET_END) || (char == LIQUID_BRACKET_END)
             outside_brackets = true
             char
           elsif outside_brackets && LETTERS.key?(char)
@@ -115,6 +120,9 @@ module Pseudolocalization
             char
           end
         end.join
+
+        pseudostring = pseudostring.gsub(/⋖/, '{{')
+        pseudostring = pseudostring.gsub(/⋗/, '}}')
       end
     end
   end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -30,4 +30,8 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_works_with_arrays
     assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
   end
+
+  def test_it_works_with_liquid_tags
+    assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ {{ firstname }} {{ lastname }}!'], @backend.translate(:en, ['Hello, world {{ firstname }} {{ lastname }}!'], {}))
+  end
 end


### PR DESCRIPTION
When there are liquid tags in a string, the var names also get converted to Pseudo versions which cause JS errors. 

Eg. 
![image](https://user-images.githubusercontent.com/958925/38266993-16a0e540-3748-11e8-8893-eadb40e99254.png)

This PR ignores anything inside a liquid tag when translating a string.