### PR TITLE
Add package cloud to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in pseudolocalization.gemspec
 gemspec
+
+group :deployment do
+  gem 'package_cloud'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudolocalization (0.2.0)
+    pseudolocalization (0.5.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This PR should fix the broken state which prevents to deploy on `pseudolocalization`.

Indeed pseudolocalization does not look available on [package cloud](https://gems.shopify.io/packages?utf8=%E2%9C%93&q=pseudolocalization&commit=Search).

- ✅ Add the package cloud to the gemfile

Last step of the [guide](https://development.shopify.io/guides/package_cloud_gems#3_Check_your_Gemfile_).

cc @christianblais 