### PR TITLE
Remove director

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,4 +1,3 @@
-director: christianblais
 owners:
   - Shopify/i18n
 slack_channels:


### PR DESCRIPTION
**Owners**: @Shopify/i18n
**Service**: [pseudolocalization/production](https://services.shopify.io/services/pseudolocalization/production)

Director ownership has been deprecated in favour of Product/Service Line ownership.

For more information on service ownership, you can read the docs in [Services DB](https://services.shopify.io/doc/ownership).
