### PR TITLE
Escape URLs

### DIFF
--- a/lib/pseudolocalization/pseudolocalizer.rb
+++ b/lib/pseudolocalization/pseudolocalizer.rb
@@ -3,11 +3,10 @@ module Pseudolocalization
     class Pseudolocalizer
       ESCAPED_REGEX = Regexp.new("(#{
         [
-          %w(<   >),
-          %w({{ }}),
-        ].map do |(a, b)|
-          "#{a}.*?#{b}"
-        end.join('|')
+          "<.*?>",
+          "{{.*?}}",
+          "https?:\/\/\\S+"
+        ].join('|')
       })")
 
       VOWELS = %w(a e i o u y A E I O U Y)

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -23,6 +23,10 @@ class PseudolocalizationTest < Minitest::Test
     assert_equal 'Ṕḽḛḛααṡḛḛ, <a href="#test">ͼḽḭḭͼḳ ḥḛḛṛḛḛ</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
   end
 
+  def test_it_works_with_http_links
+    assert_equal 'Ṕḽḛḛααṡḛḛ, http://google.com/search ḭḭṡ ṭḥḛḛ 💩!', @backend.translate(:en, 'Please, http://google.com/search is the 💩!', {})
+  end
+
   def test_it_works_with_hashes
     assert_equal({ name: 'Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!' }, @backend.translate(:en, { name: 'Hello, world!' }, {}))
   end


### PR DESCRIPTION
Shopify currently explodes when links are pseudotranslated, as `ḥṭṭp://ḡṓṓṓṓḡḽḛḛ.ͼṓṓṃ` doesn't resolve as a valid URL. This fixes that.