### PR TITLE
Escape quotes inside attributes

### DIFF
--- a/lib/pseudolocalization/pseudolocalizer.rb
+++ b/lib/pseudolocalization/pseudolocalizer.rb
@@ -5,7 +5,8 @@ module Pseudolocalization
         [
           "<.*?>",
           "{{.*?}}",
-          "https?:\/\/\\S+"
+          "https?:\/\/\\S+",
+          "&.*?;"
         ].join('|')
       })")
 
@@ -86,7 +87,6 @@ module Pseudolocalization
         end
 
         def translate_string(string)
-          string = string.gsub(/&[a-z&&[^quot]]+;/, ' ')
 
           string.split(ESCAPED_REGEX).map do |part|
             if part =~ ESCAPED_REGEX

--- a/lib/pseudolocalization/pseudolocalizer.rb
+++ b/lib/pseudolocalization/pseudolocalizer.rb
@@ -86,7 +86,7 @@ module Pseudolocalization
         end
 
         def translate_string(string)
-          string = string.gsub(/&[a-z]+;/, ' ')
+          string = string.gsub(/&[a-z&&[^quot]]+;/, ' ')
 
           string.split(ESCAPED_REGEX).map do |part|
             if part =~ ESCAPED_REGEX

--- a/lib/pseudolocalization/pseudolocalizer.rb
+++ b/lib/pseudolocalization/pseudolocalizer.rb
@@ -6,7 +6,7 @@ module Pseudolocalization
           "<.*?>",
           "{{.*?}}",
           "https?:\/\/\\S+",
-          "&.*?;"
+          "&\\S*?;"
         ].join('|')
       })")
 

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -23,6 +23,13 @@ class PseudolocalizationTest < Minitest::Test
     assert_equal 'Ṕḽḛḛααṡḛḛ, <a href="#test">ͼḽḭḭͼḳ ḥḛḛṛḛḛ</a>!', @backend.translate(:en, 'Please, <a href="#test">click here</a>!', {})
   end
 
+  def test_it_does_not_pseudolocalize_html_entities
+    assert_equal(
+      '<span bind="func(&quot;product&quot;)"></span>',
+      @backend.translate(:en, '<span bind="func(&quot;product&quot;)"></span>', {})
+    )
+  end
+
   def test_it_works_with_http_links
     assert_equal 'Ṕḽḛḛααṡḛḛ, http://google.com/search ḭḭṡ ṭḥḛḛ 💩!', @backend.translate(:en, 'Please, http://google.com/search is the 💩!', {})
   end


### PR DESCRIPTION
### What are you trying to accomplish?
Fixes https://github.com/Shopify/shopify/issues/183600

Issue:

`bind="selectedItemsString(&quot;product&quot;)"` is translated to:
 `bind="selectedItemsString( product )"`

Ideally:

`bind="selectedItemsString(&quot;product&quot;)"` should be translated to:
 `bind="selectedItemsString(&quot;product&quot;)"`

🎩 'ing Instructions:

1. Clone the pseudolocalization code.
2. `git checkout escape-quotes`
3. In gemfile of Shopify/shopify: `gem 'pseudolocalization', :path => '/Users/path_to_local_gem'`
4. In Shopify/shopify: `dev up && I18N_BACKEND=pseudolocalization dev s`