### PR TITLE
Add attr_reader to Backend

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudolocalization (0.5.0)
+    pseudolocalization (0.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -48,4 +48,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -4,24 +4,26 @@ require_relative "pseudolocalization/pseudolocalizer"
 module Pseudolocalization
   module I18n
     class Backend
+      attr_reader :old_backend
+
       def initialize(old_backend)
         @old_backend = old_backend
       end
 
       def method_missing(name, *args, &block)
         if respond_to_missing?(name)
-          @old_backend.public_send(name, *args, &block)
+          old_backend.public_send(name, *args, &block)
         else
           super
         end
       end
 
       def respond_to_missing?(name, include_private = false)
-        @old_backend.respond_to?(name) || super
+        old_backend.respond_to?(name) || super
       end
 
       def translate(locale, key, options)
-        ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(@old_backend.translate(locale, key, options))
+        ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(old_backend.translate(locale, key, options))
       end
     end
   end

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -4,26 +4,26 @@ require_relative "pseudolocalization/pseudolocalizer"
 module Pseudolocalization
   module I18n
     class Backend
-      attr_reader :old_backend
+      attr_reader :original_backend
 
-      def initialize(old_backend)
-        @old_backend = old_backend
+      def initialize(original_backend)
+        @original_backend = original_backend
       end
 
       def method_missing(name, *args, &block)
         if respond_to_missing?(name)
-          old_backend.public_send(name, *args, &block)
+          original_backend.public_send(name, *args, &block)
         else
           super
         end
       end
 
       def respond_to_missing?(name, include_private = false)
-        old_backend.respond_to?(name) || super
+        original_backend.respond_to?(name) || super
       end
 
       def translate(locale, key, options)
-        ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(old_backend.translate(locale, key, options))
+        ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(original_backend.translate(locale, key, options))
       end
     end
   end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -15,6 +15,10 @@ class PseudolocalizationTest < Minitest::Test
     refute_nil ::Pseudolocalization::VERSION
   end
 
+  def test_it_exposes_old_backend
+    assert_instance_of DummyBackend, @backend.old_backend
+  end
+
   def test_it_pseudolocalizes
     assert_equal 'Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!', @backend.translate(:en, 'Hello, world!', {})
   end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -15,8 +15,8 @@ class PseudolocalizationTest < Minitest::Test
     refute_nil ::Pseudolocalization::VERSION
   end
 
-  def test_it_exposes_old_backend
-    assert_instance_of DummyBackend, @backend.old_backend
+  def test_it_exposes_original_backend
+    assert_instance_of DummyBackend, @backend.original_backend
   end
 
   def test_it_pseudolocalizes


### PR DESCRIPTION
I noticed that the `@old_backend` was saved, but not exposed. This PR exposes it via `attr_reader` so consumers don't have to use the expensive `instance_variable_get` method to access it.

---

The project I'm working on using translations to translate URL segments. This causes Rails to blow up because the paths become things like `/sell/ͼḽṓṓṭḥḛḛṡ`. Fortunately the logic for doing this is well contained and it's possible for me to switch the backend back to the original, let it do it's thing, and then switch it back to pseudolocalization.

Having the `@old_backend` exposed makes this much easier.