### PR TITLE
Fix README gem version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pseudolocalization [![Version][gem]][gem_url] [![Build Status](https://travis-ci.org/Shopify/pseudolocalization.svg?branch=master)](https://travis-ci.org/Shopify/pseudolocalization)
 
-[gem]: https://img.shields.io/gem/v/pseudolocalization.svg
+[gem]: https://badge.fury.io/rb/pseudolocalization.svg
 [gem_url]: https://rubygems.org/gems/pseudolocalization
 
 > Pseudolocalization (or pseudo-localization) is a software testing method used for testing internationalization aspects of software. Instead of translating the text of the software into a foreign language, as in the process of localization, the textual elements of an application are replaced with an altered version of the original language.


### PR DESCRIPTION
I'm finding that half the time I load the README the gem version badge from `img.shields.io` simply doesn't load. Plus, the style kinda clashes with the CI badge. Upgrade to a `badge.fury.io` badge should fix both of those issues.