### PR TITLE
Upgrade local/test Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
 before_install:
   - gem update --system
   - gem install bundler -v '1.17.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Added `ci_url` to `service.yml`. [#27](https://github.com/shopify/pseudolocalization/pull/27)
-- Added this CHANGELOG.md. []()
+- Added this CHANGELOG.md. [#32](https://github.com/Shopify/pseudolocalization/pull/32)
+- Switched to Ruby 2.6.5 for development. [#33](https://github.com/Shopify/pseudolocalization/pull/33)
 
 ### Changed
 - Upgraded `minitest` to v5.12.0. [#29](https://github.com/shopify/pseudolocalization/pull/29)

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: pseudolocalization
 type: ruby
 
 up:
-  - ruby: 2.6.3
+  - ruby: 2.6.5
   - bundler
 
 commands:


### PR DESCRIPTION
Upgrade the local development version to [Ruby 2.6.5](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/) and upgrade our test versions on Travis to the latest versions as well, [2.4.9](https://www.ruby-lang.org/en/news/2019/10/02/ruby-2-4-9-released/), [2.5.7](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-5-7-released/), and [2.6.5](https://www.ruby-lang.org/en/news/2019/10/01/ruby-2-6-5-released/).