### PR TITLE
Upgrade to Ruby 2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
 before_install:
   - gem update --system
   - gem install bundler -v '1.17.3'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Upgraded `minitest` to v5.13.0. [#36](https://github.com/Shopify/pseudolocalization/pull/36)
 - Upgraded `rake` to v13.0.1. [#37](https://github.com/Shopify/pseudolocalization/pull/37)
 - Upgraded `minitest` to v5.14.0. [#38](https://github.com/Shopify/pseudolocalization/pull/38)
+- Switched to Ruby 2.7.0 for development. [#39](https://github.com/Shopify/pseudolocalization/pull/39)
 
 ## [0.8.2] - 2019-10-08
 ### Added

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: pseudolocalization
 type: ruby
 
 up:
-  - ruby: 2.6.5
+  - ruby: 2.7.0
   - bundler
 
 commands:


### PR DESCRIPTION
Quick upgrade to [Ruby 2.7.0](https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/).