### PR TITLE
Release 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [0.8.3] - 2020-01-15
 ### Added
 - Added CLA probot to legitimize external contributions. [#35](https://github.com/shopify/pseudolocalization/pull/35)
 
@@ -53,7 +55,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Please refer to [GitHub releases](https://github.com/Shopify/pseudolocalization/releases) for releases prior to [0.8.0].
 
-[Unreleased]: https://github.com/Shopify/pseudolocalization/compare/0.8.2...HEAD
+[Unreleased]: https://github.com/Shopify/pseudolocalization/compare/0.8.3...HEAD
+[0.8.3]: https://github.com/Shopify/pseudolocalization/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/Shopify/pseudolocalization/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/Shopify/pseudolocalization/compare/0.8.0...0.8.1
 [0.8.0]: https://github.com/Shopify/pseudolocalization/compare/0.7.0...0.8.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudolocalization (0.8.2)
+    pseudolocalization (0.8.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/pseudolocalization/version.rb
+++ b/lib/pseudolocalization/version.rb
@@ -1,3 +1,3 @@
 module Pseudolocalization
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end


### PR DESCRIPTION
### Added
- Added CLA probot to legitimize external contributions. [#35](https://github.com/shopify/pseudolocalization/pull/35)

### Changed
- Upgraded `minitest` to v5.13.0. [#36](https://github.com/Shopify/pseudolocalization/pull/36)
- Upgraded `rake` to v13.0.1. [#37](https://github.com/Shopify/pseudolocalization/pull/37)
- Upgraded `minitest` to v5.14.0. [#38](https://github.com/Shopify/pseudolocalization/pull/38)
- Switched to Ruby 2.7.0 for development. [#39](https://github.com/Shopify/pseudolocalization/pull/39)
- Upgraded `bundler` to v2.1.4. [#40](https://github.com/Shopify/pseudolocalization/pull/40)