### PR TITLE
Automerge updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,18 +1,13 @@
 version: 1
 update_configs:
-  # Update your Gemfile (& lockfiles) as soon as
-  # new versions are published to the RubyGems registry
-  - package_manager: "ruby:bundler"
-    directory: "/"
-    update_schedule: "weekly"
-
-    # Apply default reviewer and label to created
-    # pull requests
-    default_reviewers:
-      - ChristianBlais
-      - larouxn
-    default_labels:
-      - "Gem upgrades"
-
+- package_manager: "ruby:bundler"
+  directory: "/"
+  update_schedule: "weekly"
+  automerged_updates:
+      - match:
+        dependency_type: "all"
+        update_type: "all"
     version_requirement_updates: "auto"
-
+  default_reviewers:
+    - larouxn
+    - ChristianBlais


### PR DESCRIPTION
In an effort to reduce the manual work of merging simple gem upgrades, I've opted to enable automerge functionality. This will merge any Dependabot created gem upgrade PR so long as tests are ✅ .

I've been personally testing this functionality on my own Rails project ([carrotgram](https://github.com/larouxn/carrotgram)) for months now and found it super convenient as I get notified of PR creation and merge via email but don't have to do anything as it's all handled automatically. 😌 

Note, automerge settings are maintained at a Shopify organization level and thus, we cannot change them per repo. In the end, I think this is fine.