### PR TITLE
Fix double translation testing

### DIFF
--- a/lib/pseudolocalization/pseudolocalizer.rb
+++ b/lib/pseudolocalization/pseudolocalizer.rb
@@ -5,6 +5,7 @@ module Pseudolocalization
         [
           "<.*?>",
           "{{.*?}}",
+          "%{.*?}",
           "https?:\/\/\\S+",
           "&\\S*?;"
         ].join('|')

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -49,4 +49,8 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_works_with_liquid_tags
     assert_equal('Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ {{ firstname }} {{lastname}}!', @backend.translate(:en, 'Hello, world {{ firstname }} {{lastname}}!', {}))
   end
+  
+  def test_it_works_with_templates
+    assert_equal('Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ %{firstname} %{lastname}!', @backend.translate(:en, 'Hello, world %{firstname} %{lastname}!', {}))
+  end
 end


### PR DESCRIPTION
In few places we use double translation. We push a rails translated string to coffee script and again localize there. This change escapes the `%{}` wrapped keys.