### PR TITLE
Ruby 3 support

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
         gemfile:
           - Gemfile
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Switched to Ruby 2.7.1 for development. [#45](https://github.com/Shopify/pseudolocalization/pull/45)
 - Switched to GitHub Actions for CI. [#52](https://github.com/Shopify/pseudolocalization/pull/52)
+- Added support for Ruby 3.0.0. [#53](https://github.com/Shopify/pseudolocalization/pull/53)
 
 ## [0.8.3] - 2020-01-15
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '~> 2.4'
+ruby '>= 2.4'
 
 source "https://rubygems.org"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,4 +50,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.3
+   2.2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ DEPENDENCIES
   rake (~> 13.0)
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 3.0.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/shipit.yml
+++ b/shipit.yml
@@ -4,6 +4,7 @@ ci:
     - 'Ruby 2.5 Gemfile'
     - 'Ruby 2.6 Gemfile'
     - 'Ruby 2.7 Gemfile'
+    - 'Ruby 3.0 Gemfile'
 deploy:
   override:
     - bundle exec rake build


### PR DESCRIPTION
Add support and CI testing for Ruby 3.0.0 by removing Ruby ~> 2.4 requirement and updating CI config.

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/