### PR TITLE
Ruby 2.7.2 in development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Switched to Ruby 2.7.1 for development. [#45](https://github.com/Shopify/pseudolocalization/pull/45)
 - Switched to GitHub Actions for CI. [#52](https://github.com/Shopify/pseudolocalization/pull/52)
 - Added support for Ruby 3.0.0. [#53](https://github.com/Shopify/pseudolocalization/pull/53)
+- Switched to Ruby 2.7.2 for development. [#54](https://github.com/Shopify/pseudolocalization/pull/54)
 
 ## [0.8.3] - 2020-01-15
 ### Added

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: pseudolocalization
 type: ruby
 
 up:
-  - ruby: 2.7.1
+  - ruby: 2.7.2
   - bundler
 
 commands:


### PR DESCRIPTION
Use Ruby 2.7.2 in dev environment.

Follow-up to https://github.com/Shopify/pseudolocalization/pull/45

Side note, planning to cut a release of this gem soon, post adding Ruby 3.0 support (https://github.com/Shopify/pseudolocalization/pull/53). Hence this micro change.