### PR TITLE
Release 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+Nil.
+
+## [0.8.4] - 2021-01-15
+### Added
+- Added support for Ruby 3. [#53](https://github.com/Shopify/pseudolocalization/pull/53)
+
 ### Changed
-- Switched to Ruby 2.7.1 for development. [#45](https://github.com/Shopify/pseudolocalization/pull/45)
 - Switched to GitHub Actions for CI. [#52](https://github.com/Shopify/pseudolocalization/pull/52)
-- Added support for Ruby 3.0.0. [#53](https://github.com/Shopify/pseudolocalization/pull/53)
-- Switched to Ruby 2.7.2 for development. [#54](https://github.com/Shopify/pseudolocalization/pull/54)
+- Switched to Ruby 2.7.2 for development. [#55](https://github.com/Shopify/pseudolocalization/pull/55)
 
 ## [0.8.3] - 2020-01-15
 ### Added
@@ -44,7 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Please refer to [GitHub releases](https://github.com/Shopify/pseudolocalization/releases) for releases prior to [0.8.0].
 
-[Unreleased]: https://github.com/Shopify/pseudolocalization/compare/0.8.3...HEAD
+[Unreleased]: https://github.com/Shopify/pseudolocalization/compare/0.8.4...HEAD
+[0.8.4]: https://github.com/Shopify/pseudolocalization/compare/0.8.3...0.8.4
 [0.8.3]: https://github.com/Shopify/pseudolocalization/compare/0.8.2...0.8.3
 [0.8.2]: https://github.com/Shopify/pseudolocalization/compare/0.8.1...0.8.2
 [0.8.1]: https://github.com/Shopify/pseudolocalization/compare/0.8.0...0.8.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudolocalization (0.8.3)
+    pseudolocalization (0.8.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/pseudolocalization/version.rb
+++ b/lib/pseudolocalization/version.rb
@@ -1,3 +1,3 @@
 module Pseudolocalization
-  VERSION = "0.8.3"
+  VERSION = "0.8.4"
 end


### PR DESCRIPTION
### Added
- Added support for Ruby 3. [#53](https://github.com/Shopify/pseudolocalization/pull/53)

### Changed
- Switched to GitHub Actions for CI. [#52](https://github.com/Shopify/pseudolocalization/pull/52)
- Switched to Ruby 2.7.2 for development. [#55](https://github.com/Shopify/pseudolocalization/pull/55)