### PR TITLE
[CI] Run GitHub Actions CI on PRs

### DIFF
--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+      - '**'
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ruby-ci.yml
+++ b/.github/workflows/ruby-ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  - push
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Run GitHub CI on PRs as well as push. I believe this mostly handles external PRs as they would _not_ cause a push event within the repository, by nature of being from a fork. Can see an example of this config in [Shopify/polaris-react](https://github.com/Shopify/polaris-react/blob/e2d5245e247753fa0fb936bba579c5b16beee75f/.github/workflows/ci.yml#L3-L10).

Based on the GitHub Actions [example-using-a-list-of-events](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-using-a-list-of-events) documentation.

Inspired by https://github.com/activemerchant/payment_icons/pull/399 which shows a PR without CI.
<img width="980" alt="Screen Shot 2021-01-27 at 20 05 03" src="https://user-images.githubusercontent.com/1557529/105982722-02710e00-60db-11eb-942a-1898c5b8451a.png">

Follow-up to https://github.com/Shopify/pseudolocalization/pull/52