### PR TITLE
Allow ignoring certain keys for pseudolocalization treatment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
- - Added support for ignoring specific translation keys
+ - Added support for ignoring specific translation keys [#59](https://github.com/Shopify/pseudolocalization/pull/59)
 
 ## [0.8.4] - 2021-01-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-Nil.
+ - Added support for ignoring specific translation keys
 
 ## [0.8.4] - 2021-01-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ When working on internationalization, you can boot your server with the pseudolo
 I18N_BACKEND=pseudolocalization bundle exec rails server
 ```
 
+### Ignoring specific keys
+You may wish to have the backend ignore specific keys. These may be configured via an array, `ignores`, on the backend. The array can contain a mix of strings (with globbing allowed) and/or Regexes.
+
+```ruby
+I18n.backend = Pseudolocalization::I18n::Backend.new(I18n.backend)
+I18n.backend.ignores = ['ignored*', /Waldo.$/]
+```
 
 ## Other Resources
 

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -5,9 +5,12 @@ module Pseudolocalization
   module I18n
     class Backend
       attr_reader :original_backend
+      attr_accessor :ignores
 
       def initialize(original_backend)
         @original_backend = original_backend
+        @ignores = []
+        yield self if block_given?
       end
 
       def method_missing(name, *args, &block)
@@ -23,7 +26,27 @@ module Pseudolocalization
       end
 
       def translate(locale, key, options)
+        return original_backend.translate(locale, key, options) if key_ignored?(key)
+
         ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(original_backend.translate(locale, key, options))
+      end
+
+      private
+
+      def key_ignored?(key)
+        return false unless ignores
+
+        ignores.any? do |ignore|
+          case ignore
+          when Regexp
+            key.to_s.match(ignore)
+          when String
+            File.fnmatch(ignore, key.to_s)
+          else
+            Rails.logger.tagged('Pseudolocalization I18n').error 'Ignore type unsupported. Expects an array of (mixed) Regexp or Strings.'
+            return false
+          end
+        end
       end
     end
   end

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -43,8 +43,8 @@ module Pseudolocalization
           when String
             File.fnmatch(ignore, key.to_s)
           else
-            Rails.logger.tagged('Pseudolocalization I18n').error 'Ignore type unsupported. Expects an array of (mixed) Regexp or Strings.'
-            return false
+            Rails.logger.tagged('Pseudolocalization I18n').error('Ignore type unsupported. Expects an array of (mixed) Regexp or Strings.')
+            false
           end
         end
       end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -15,6 +15,12 @@ class PseudolocalizationTest < Minitest::Test
     refute_nil ::Pseudolocalization::VERSION
   end
 
+  def test_that_it_supports_block_initialization
+    Pseudolocalization::I18n::Backend.new(DummyBackend.new) do |instance|
+      assert_instance_of Pseudolocalization::I18n::Backend, instance
+    end
+  end
+
   def test_it_exposes_original_backend
     assert_instance_of DummyBackend, @backend.original_backend
   end
@@ -49,7 +55,7 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_works_with_liquid_tags
     assert_equal('Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ {{ firstname }} {{lastname}}!', @backend.translate(:en, 'Hello, world {{ firstname }} {{lastname}}!', {}))
   end
-  
+
   def test_it_works_with_templates
     assert_equal('Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ %{firstname} %{lastname}!', @backend.translate(:en, 'Hello, world %{firstname} %{lastname}!', {}))
   end
@@ -59,5 +65,6 @@ class PseudolocalizationTest < Minitest::Test
 
     assert_equal('Ignore me, World!', @backend.translate(:en, 'Ignore me, World!', {}))
     assert_equal('Ignore me, as well Clifford!', @backend.translate(:en, 'Ignore me, as well Clifford!', {}))
+    assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
   end
 end

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -53,4 +53,11 @@ class PseudolocalizationTest < Minitest::Test
   def test_it_works_with_templates
     assert_equal('Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ %{firstname} %{lastname}!', @backend.translate(:en, 'Hello, world %{firstname} %{lastname}!', {}))
   end
+
+  def test_it_allows_ignoring_cetain_keys
+    @backend.ignores = ['Ignore*', /Clifford.$/]
+
+    assert_equal('Ignore me, World!', @backend.translate(:en, 'Ignore me, World!', {}))
+    assert_equal('Ignore me, as well Clifford!', @backend.translate(:en, 'Ignore me, as well Clifford!', {}))
+  end
 end


### PR DESCRIPTION
There are some situations where it actually breaks things to apply the psuedo-treatment (such as when you are accessing formats for dates, or with the translation is used to build a filename and therefore creates invalid filenames such as `fîlé.çśv`)

Lastly, there are situations such as `_html` translations, where the translation produces invalid html with tags such as `<âá hréf="foo">`, etc.

I'm open to changes with how you want to deal with configurable parameters since the library current doesn't need it.