### PR TITLE
Fix README version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pseudolocalization [![Version][gem]][gem_url] [![Build Status](https://github.com/Shopify/pseudolocalization/workflows/CI/badge.svg?branch=master)](https://github.com/Shopify/pseudolocalization/actions?query=workflow%3ACI)
 
-[gem]: https://badge.fury.io/rb/pseudolocalization.svg
+[gem]: https://badgen.net/rubygems/v/pseudolocalization
 [gem_url]: https://rubygems.org/gems/pseudolocalization
 
 > Pseudolocalization (or pseudo-localization) is a software testing method used for testing internationalization aspects of software. Instead of translating the text of the software into a foreign language, as in the process of localization, the textual elements of an application are replaced with an altered version of the original language.


### PR DESCRIPTION
Replaced [badge.fury.io](https://badge.fury.io/) with [badgen.net/rubygems](https://badgen.net/rubygems) as the former doesn't load anymore.
<img width="992" alt="Screen Shot 2021-02-03 at 14 55 47" src="https://user-images.githubusercontent.com/1557529/106704708-ea940f80-662f-11eb-925c-acdf941a39eb.png">
