### PR TITLE
Revert "Release 0.9.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-Nil.
-
-## [0.9.0] - 2021-02-15
-### Added
- - Added support for ignoring specific translation keys. [#59](https://github.com/Shopify/pseudolocalization/pull/59)
+ - Added support for ignoring specific translation keys [#59](https://github.com/Shopify/pseudolocalization/pull/59)
 
 ## [0.8.4] - 2021-01-15
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pseudolocalization (0.9.0)
+    pseudolocalization (0.8.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/pseudolocalization/version.rb
+++ b/lib/pseudolocalization/version.rb
@@ -1,3 +1,3 @@
 module Pseudolocalization
-  VERSION = "0.9.0"
+  VERSION = "0.8.4"
 end


### PR DESCRIPTION
Reverts Shopify/pseudolocalization#65

Reverting release to fix deploy process. Will attempt redeploy once deploy changes are in place.