### PR TITLE
Fix deploys

### DIFF
--- a/shipit.rubygems.yml
+++ b/shipit.rubygems.yml
@@ -1,3 +1,9 @@
+deploy:
+  override:
+    - bundle exec rake build
+    - gem push --key github_registry --host https://rubygems.pkg.github.com/shopify pkg/*.gem
+    - bundle exec package_cloud push shopify/gems pkg/*.gem
+
 ci:
   require:
     - 'Ruby 2.4 Gemfile'


### PR DESCRIPTION
⚠️ DO NOT MERGE | WIP ⚠️ 

Fix deploys which are currently broken ([deploy log](https://shipit.shopify.io/shopify/pseudolocalization/rubygems/deploys/1181830)), seemingly due to the lack of `v` in this gem's versions. 🤔 

Upside is with this fix we _can_ continue deploying to PackageCloud as well. 🤷‍♂️ 