### PR TITLE
Remove Ruby version and package_cloud from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,4 @@
-ruby '>= 2.4'
-
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pseudolocalization.gemspec
 gemspec
-
-group :deployment do
-  gem 'package_cloud'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,48 +6,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    highline (1.6.20)
-    http-accept (1.7.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
-    json_pure (1.8.1)
-    mime-types (3.2.2)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
     minitest (5.14.3)
-    netrc (0.11.0)
-    package_cloud (0.3.05)
-      highline (= 1.6.20)
-      json_pure (= 1.8.1)
-      rainbow (= 2.2.2)
-      rest-client (~> 2.0)
-      thor (~> 0.18)
-    rainbow (2.2.2)
-      rake
     rake (13.0.3)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    thor (0.20.3)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.6)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   minitest (~> 5.0)
-  package_cloud
   pseudolocalization!
   rake (~> 13.0)
-
-RUBY VERSION
-   ruby 3.0.0p0
 
 BUNDLED WITH
    2.2.4


### PR DESCRIPTION
- Remove the Ruby version declaration as it causes issues with the default deploy process. The specific issue is that said process removes Ruby version declarations ([code](https://github.com/Shopify/shipit-engine/blob/a4899ed60a23c2d05d74ede3a683f82907d4232f/app/models/shipit/deploy_spec/bundler_discovery.rb#L33)) which thusly generates an uncommitted change which then fails the deploy as it expects a clean diff.
- Remove `package_cloud` as we're going all in on RubyGems for this gem (keeps deploys simple too!)