### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,4 +18,4 @@ DEPENDENCIES
   rake (~> 13.0)
 
 BUNDLED WITH
-   2.2.4
+   2.2.22


### PR DESCRIPTION
Before Bundler version `2.2.18`, the `Gemfile.lock` didn’t specify the source priority, potentially causing private gem names to be name-squatted on public gem sources. In particular, indirect dependencies were subject to this problem. The newer versions of bundler explicitly define the source of a gem, which solves the problem.

This PR updates Bundler to 2.2.22 and regenerates the `Gemfile.lock` in the new format. Please make sure that the gem versions are correct, adjust where necessary, and merge it.

## What will happen if it doesn't get done within the expected timeframe?

Shortly, support for Bundler <2.2.18 will no longer be an option. Therefore services that run on an outdated Bundler won't be able to run CI or deploy.

## What to do if Gemfile.lock keeps changing after `dev up` or `bundle install`

This might mean that you're on the older version of `dev`. Please try running `dev update` and then `dev up` and make sure Gemfile.lock does not change.

## I have questions/concerns about this

Have a look at our [troubleshooting documentation](https://docs.google.com/document/d/1___u8tHiyosnJcGc4VYH3JYZNhBmu6TawpmE6oeuR8U/edit#) in case you run into any issues. Feel free to contact the Ruby Conventions team using #code-foundations if you run into issues that aren’t covered by the documentation.

Tracker: https://github.com/Shopify/code-foundations/issues/116