### PR TITLE
Add support for pseudolocalized `translations`

### DIFF
--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -2,6 +2,12 @@ require "test_helper"
 
 class PseudolocalizationTest < Minitest::Test
   class DummyBackend
+    attr_accessor :translations
+
+    def initialize(translations = {})
+      @translations = translations
+    end
+
     def translate(_locale, string, _options)
       string
     end
@@ -66,5 +72,53 @@ class PseudolocalizationTest < Minitest::Test
     assert_equal('Ignore me, World!', @backend.translate(:en, 'Ignore me, World!', {}))
     assert_equal('Ignore me, as well Clifford!', @backend.translate(:en, 'Ignore me, as well Clifford!', {}))
     assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
+  end
+
+  def test_it_exposes_pseudo_localized_translations
+    translations = {
+      en: {
+        date: {
+          day_names: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+        },
+        hello: 'Hello, world!',
+        ignored: {
+          foobar: "Foobar"
+        }
+      },
+      es: {
+        date: {
+          day_names: ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes'],
+        },
+        hello: 'Hola, mundo!',
+        ignored: {
+          foobar: "Foobar"
+        }
+      }
+    }
+    expected = {
+      en: {
+        date: {
+          day_names: ["Ṣṵṵṇḍααẏẏ", "Ṁṓṓṇḍααẏẏ", "Ṫṵṵḛḛṡḍααẏẏ", "Ŵḛḛḍṇḛḛṡḍααẏẏ", "Ṫḥṵṵṛṡḍααẏẏ", "Ḟṛḭḭḍααẏẏ"],
+        },
+        hello: "Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!",
+        ignored: {
+          foobar: "Foobar"
+        }
+      },
+      es: {
+        date: {
+          day_names: ["Ḍṓṓṃḭḭṇḡṓṓ", "Ḻṵṵṇḛḛṡ", "Ṁααṛṭḛḛṡ", "Ṁḭḭéṛͼṓṓḽḛḛṡ", "Ĵṵṵḛḛṽḛḛṡ", "Ṿḭḭḛḛṛṇḛḛṡ"],
+        },
+        hello: "Ḥṓṓḽαα, ṃṵṵṇḍṓṓ!",
+        ignored: {
+          foobar: "Foobar"
+        }
+      }
+    }
+
+    @backend = Pseudolocalization::I18n::Backend.new(DummyBackend.new(translations))
+    @backend.ignores = ["ignored*"]
+
+    assert_equal(expected, @backend.translations)
   end
 end


### PR DESCRIPTION
I am working on a Rails project that uses the [i18n-js](https://github.com/fnando/i18n-js) gem to export translations to the frontend. I wanted to use this gem to apply pseudolocalization to the project, for all the reasons listed in the readme 🙂. But I ran into a problem.

i18n-js relies on calling the I18n backend's `translations` method to get the full hash of translations, which it then filters/converts/exports to JS. Currently, `Pseudolocalization::I18n::Backend` only applies the pseudo-l10n transformations to `translate` calls, and so calling `translations` returns the un-transformed original translations hash.

In this PR, I added an implementation of `translations` to `Pseudolocalization::I18n::Backend`, which walks through the original translations hash, applying `pseudolocalize` to the contents. It respects the `ignores` configuration, so keys that would be ignored on a direct `translate` call are also ignored when they are exported in the full translations hash.

I am a little unsure if I correctly integrated `key_ignored?` into my logic. It wasn't immediately clear to me if the `key` argument was supposed to be something like a full dotted path (e.g. `activerecord.errors.taken`), or just the key closest to the value, without ancestors (e.g. just `taken`). I assumed it's the full path, but please correct me if I'm wrong!

Finally, I also added an implementation of `init_translations`, which is also called by i18n-js before it exports. It just delegates to the original, but has to use `send`, because `init_translations` is protected.