### PR TITLE
feat: allow for restricting the locales affected

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ I18n.backend = Pseudolocalization::I18n::Backend.new(I18n.backend)
 I18n.backend.ignores = ['ignored*', /Waldo.$/]
 ```
 
+### Apply only to specific locales
+You may wish to have the backend only apply to specific locales. These may be configured via an array, `only_locales`, on the backend.
+
+```ruby
+I18n.backend = Pseudolocalization::I18n::Backend.new(I18n.backend)
+I18n.backend.only_locales = [:en, :xx, :zz]
+```
+
 ### How to run tests
 
 ```bash

--- a/lib/pseudolocalization.rb
+++ b/lib/pseudolocalization.rb
@@ -5,11 +5,12 @@ module Pseudolocalization
   module I18n
     class Backend
       attr_reader :original_backend
-      attr_accessor :ignores
+      attr_accessor :ignores, :only_locales
 
       def initialize(original_backend)
         @original_backend = original_backend
         @ignores = []
+        @only_locales = []
         yield self if block_given?
       end
 
@@ -26,7 +27,7 @@ module Pseudolocalization
       end
 
       def translate(locale, key, options)
-        return original_backend.translate(locale, key, options) if key_ignored?(key)
+        return original_backend.translate(locale, key, options) if key_ignored?(key) || locale_ignored?(locale)
 
         ::Pseudolocalization::I18n::Pseudolocalizer.pseudolocalize(original_backend.translate(locale, key, options))
       end
@@ -39,6 +40,12 @@ module Pseudolocalization
       end
 
       private
+
+      def locale_ignored?(locale)
+        return false if only_locales.empty?
+
+        !only_locales.include?(locale)
+      end
 
       def key_ignored?(key)
         return false unless ignores

--- a/test/pseudolocalization_test.rb
+++ b/test/pseudolocalization_test.rb
@@ -74,6 +74,13 @@ class PseudolocalizationTest < Minitest::Test
     assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
   end
 
+  def test_it_allows_only_cetain_locales
+    @backend.only_locales = [:en]
+
+    assert_equal('Ignore me, World!', @backend.translate(:fr, 'Ignore me, World!', {}))
+    assert_equal(['Ḥḛḛḽḽṓṓ, ẁṓṓṛḽḍ!'], @backend.translate(:en, ['Hello, world!'], {}))
+  end
+
   def test_it_exposes_pseudo_localized_translations
     translations = {
       en: {


### PR DESCRIPTION
It's often useful to limit where the pseudolocalization
gets applied. This allows for checking the difference
between applied and unapplied locales. It also allows
for using a strategy where only locales such as XX or ZZ
are used.
